### PR TITLE
Upgrade CMAKE_CXX_STANDARD from 17 to 20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 
 project(EonTimer VERSION 3.0.0)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 


### PR DESCRIPTION
Building on Arch Linux I got the following error:

```
TimerService.cpp: In member function ‘std::chrono::microseconds service::TimerService::runStage(std::chrono::microseconds, std::chrono::microseconds)’:
TimerService.cpp:105:31: error: ‘sleep_for’ is not a member of ‘std::this_thread’
```

After I changed CMAKE_CXX_STANDARD to 20 the build was successful.