### PR TITLE
fix missing header for newer versions of gcc (#94)

### DIFF
--- a/src/services/TimerService.h
+++ b/src/services/TimerService.h
@@ -13,6 +13,7 @@
 #include <QThread>
 #include <memory>
 #include <vector>
+#include <thread>
 
 namespace service {
     class TimerService : public QObject {


### PR DESCRIPTION
fix failing build for gcc versions >=11. Closes #94 