### PR TITLE
Prevent calibrating when 'actual' fields have a value of 0

### DIFF
--- a/eon_timer/timers/gen3/model.py
+++ b/eon_timer/timers/gen3/model.py
@@ -3,7 +3,7 @@ from typing import override
 
 from eon_timer.util.enum import EnhancedEnum
 from eon_timer.util.injector import component
-from eon_timer.util.properties.property import Property
+from eon_timer.util.properties.property import Property, IntProperty
 from eon_timer.util.properties.settings import Settings
 
 
@@ -15,10 +15,10 @@ class Gen3Mode(EnhancedEnum, StrEnum):
 @component()
 class Gen3Model(Settings):
     mode = Property(Gen3Mode.STANDARD, value_type=str)
-    pre_timer = Property(5000)
-    target_frame = Property(1000)
-    calibration = Property(0)
-    frame_hit = Property(0, transient=True)
+    pre_timer = IntProperty(5000)
+    target_frame = IntProperty(1000)
+    calibration = IntProperty(0)
+    frame_hit = IntProperty(0, transient=True)
 
     @property
     @override

--- a/eon_timer/timers/gen3/widget.py
+++ b/eon_timer/timers/gen3/widget.py
@@ -5,7 +5,6 @@ from typing import Final
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import QGroupBox, QPushButton, QSizePolicy, QSpinBox
 
-from eon_timer.app_state import AppState
 from eon_timer.timers import FrameTimer
 from eon_timer.util import const, pyside
 from eon_timer.util.injector import component
@@ -109,13 +108,13 @@ class Gen3Widget(FormWidget):
         )
 
     def calibrate(self):
-        calibration = self.model.calibration.get()
-        offset = self.frame_timer.calibrate(
-            self.model.target_frame.get(),
-            self.model.frame_hit.get()
-        )
-        self.model.calibration.set(calibration + offset)
-        self.model.frame_hit.set(0)
+        if self.model.frame_hit.get() > 0:
+            offset = self.frame_timer.calibrate(
+                self.model.target_frame.get(),
+                self.model.frame_hit.get()
+            )
+            self.model.calibration.add(offset)
+            self.model.frame_hit.set(0)
 
     def __on_mode_changed(self, event: PropertyChangeEvent[Gen3Mode]) -> None:
         self.set_visible(self.Field.SET_TARGET_FRAME,

--- a/eon_timer/timers/gen4/model.py
+++ b/eon_timer/timers/gen4/model.py
@@ -1,17 +1,17 @@
 from typing import override
 
 from eon_timer.util.injector import component
-from eon_timer.util.properties.property import Property
+from eon_timer.util.properties.property import IntProperty
 from eon_timer.util.properties.settings import Settings
 
 
 @component()
 class Gen4Model(Settings):
-    target_delay = Property(600)
-    target_second = Property(50)
-    calibrated_delay = Property(500)
-    calibrated_second = Property(14)
-    delay_hit = Property(0, transient=True)
+    target_delay = IntProperty(600)
+    target_second = IntProperty(50)
+    calibrated_delay = IntProperty(500)
+    calibrated_second = IntProperty(14)
+    delay_hit = IntProperty(0, transient=True)
 
     @property
     @override

--- a/eon_timer/timers/gen4/widget.py
+++ b/eon_timer/timers/gen4/widget.py
@@ -5,7 +5,6 @@ from typing import Final
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import QGroupBox, QSizePolicy, QSpinBox
 
-from eon_timer.app_state import AppState
 from eon_timer.timers import Calibrator, DelayTimer
 from eon_timer.util import const, pyside
 from eon_timer.util.injector import component
@@ -102,15 +101,15 @@ class Gen4Widget(FormWidget):
         )
 
     def calibrate(self):
-        calibration = self.calibrator.to_delays(
-            self.delay_timer.calibrate(
-                self.model.target_delay.get(),
-                self.model.delay_hit.get()
+        if self.model.delay_hit.get() > 0:
+            calibration = self.calibrator.to_delays(
+                self.delay_timer.calibrate(
+                    self.model.target_delay.get(),
+                    self.model.delay_hit.get()
+                )
             )
-        )
-        calibrated_delay = self.model.calibrated_delay.get() + calibration
-        self.model.calibrated_delay.set(calibrated_delay)
-        self.model.delay_hit.set(0)
+            self.model.calibrated_delay.add(calibration)
+            self.model.delay_hit.set(0)
 
     def get_calibration(self) -> int:
         return self.calibrator.create_calibration(

--- a/eon_timer/timers/gen5/model.py
+++ b/eon_timer/timers/gen5/model.py
@@ -3,7 +3,7 @@ from typing import override
 
 from eon_timer.util.enum import EnhancedEnum
 from eon_timer.util.injector import component
-from eon_timer.util.properties.property import Property
+from eon_timer.util.properties.property import Property, IntProperty
 from eon_timer.util.properties.settings import Settings
 
 
@@ -17,15 +17,15 @@ class Gen5Mode(EnhancedEnum, StrEnum):
 @component()
 class Gen5Model(Settings):
     mode = Property(Gen5Mode.STANDARD, value_type=str)
-    calibration = Property(-95)
-    frame_calibration = Property(0)
-    entralink_calibration = Property(256)
-    target_delay = Property(1200)
-    target_second = Property(50)
-    target_advances = Property(100)
-    delay_hit = Property(0, transient=True)
-    second_hit = Property(0, transient=True)
-    advances_hit = Property(0, transient=True)
+    calibration = IntProperty(-95)
+    frame_calibration = IntProperty(0)
+    entralink_calibration = IntProperty(256)
+    target_delay = IntProperty(1200)
+    target_second = IntProperty(50)
+    target_advances = IntProperty(100)
+    delay_hit = IntProperty(0, transient=True)
+    second_hit = IntProperty(0, transient=True)
+    advances_hit = IntProperty(0, transient=True)
 
     @property
     @override

--- a/eon_timer/util/properties/property.py
+++ b/eon_timer/util/properties/property.py
@@ -37,3 +37,20 @@ class Property(Generic[T]):
     @property
     def transient(self) -> bool:
         return self.__transient
+
+
+class IntProperty(Property[int]):
+    def __init__(self, initial_value: int | None = None, transient: bool = False):
+        super().__init__(initial_value, int, transient)
+
+    def add(self, value: int):
+        self.set(self.get() + value)
+
+    def sub(self, value: int):
+        self.set(self.get() - value)
+
+    def mul(self, value: int):
+        self.set(self.get() * value)
+
+    def div(self, value: int):
+        self.set(int(self.get() / value))


### PR DESCRIPTION
Implement missing gen5 calibration logic