### PR TITLE
Add configurable minimum phase length setting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -90,7 +90,7 @@ export default function App() {
   const handleSettingsClose = useCallback(
     (accepted: boolean) => {
       setSettingsOpen(false);
-      if (accepted) updatePhases();
+      if (accepted) setTimeout(updatePhases, 0);
     },
     [updatePhases],
   );

--- a/src/components/CustomPanel.tsx
+++ b/src/components/CustomPanel.tsx
@@ -40,7 +40,8 @@ export const CustomPanel = forwardRef<TimerPanelHandle, CustomPanelProps>(
       console: timer.console,
       customFramerate: timer.customFramerate,
       precisionCalibration: timer.precisionCalibration,
-    }), [timer.console, timer.customFramerate, timer.precisionCalibration]);
+      minimumLength: timer.minimumLength * 1000,
+    }), [timer.console, timer.customFramerate, timer.precisionCalibration, timer.minimumLength]);
 
     const persist = useCallback(
       (updated: PhaseState[]) => {

--- a/src/components/Gen3Panel.tsx
+++ b/src/components/Gen3Panel.tsx
@@ -40,7 +40,8 @@ export const Gen3Panel = forwardRef<TimerPanelHandle, Gen3PanelProps>(
       console: timer.console,
       customFramerate: timer.customFramerate,
       precisionCalibration: timer.precisionCalibration,
-    }), [timer.console, timer.customFramerate, timer.precisionCalibration]);
+      minimumLength: timer.minimumLength * 1000,
+    }), [timer.console, timer.customFramerate, timer.precisionCalibration, timer.minimumLength]);
 
     const createPhases = useCallback(() => {
       return createGen3Phases(calSettings, gen3);

--- a/src/components/Gen4Panel.tsx
+++ b/src/components/Gen4Panel.tsx
@@ -24,7 +24,8 @@ export const Gen4Panel = forwardRef<TimerPanelHandle, Gen4PanelProps>(
       console: timer.console,
       customFramerate: timer.customFramerate,
       precisionCalibration: timer.precisionCalibration,
-    }), [timer.console, timer.customFramerate, timer.precisionCalibration]);
+      minimumLength: timer.minimumLength * 1000,
+    }), [timer.console, timer.customFramerate, timer.precisionCalibration, timer.minimumLength]);
 
     const createPhases = useCallback(() => {
       return createGen4Phases(calSettings, gen4);

--- a/src/components/Gen5Panel.tsx
+++ b/src/components/Gen5Panel.tsx
@@ -36,7 +36,8 @@ export const Gen5Panel = forwardRef<TimerPanelHandle, Gen5PanelProps>(
       console: timer.console,
       customFramerate: timer.customFramerate,
       precisionCalibration: timer.precisionCalibration,
-    }), [timer.console, timer.customFramerate, timer.precisionCalibration]);
+      minimumLength: timer.minimumLength * 1000,
+    }), [timer.console, timer.customFramerate, timer.precisionCalibration, timer.minimumLength]);
 
     const createPhases = useCallback(() => {
       return createGen5Phases(calSettings, gen5);

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -86,13 +86,13 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
         <div className="dialog-content">
           {tab === 0 && (
             <div className="settings-panel">
-              <FormField label="Mode">
+              <FormField label="Mode" tooltip="How the timer signals each phase transition — audio, visual flash, or both">
                 <EnumSelect values={ACTION_MODES} value={action.mode} onChange={(v) => setAction({ ...action, mode: v })} />
               </FormField>
-              <FormField label="Sound">
+              <FormField label="Sound" tooltip="Sound effect played on each action signal">
                 <EnumSelect values={ACTION_SOUNDS} value={action.sound} onChange={(v) => setAction({ ...action, sound: v })} />
               </FormField>
-              <FormField label="Color">
+              <FormField label="Color" tooltip="Flash color used for visual action alerts">
                 <input
                   type="color"
                   value={action.color}
@@ -101,10 +101,10 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
                   style={{ width: '100%' }}
                 />
               </FormField>
-              <FormField label="Interval">
+              <FormField label="Interval" tooltip="Time between action signals in milliseconds">
                 <IntInput value={action.interval} onChange={(v) => setAction({ ...action, interval: v ?? 500 })} min={0} max={INT_MAX} />
               </FormField>
-              <FormField label="Count">
+              <FormField label="Count" tooltip="Number of action signals per phase transition">
                 <IntInput value={action.count} onChange={(v) => setAction({ ...action, count: v ?? 1 })} min={0} max={INT_MAX} />
               </FormField>
               <button className="btn" style={{ width: '100%' }} onClick={handleTestAction}>Test Action</button>
@@ -112,19 +112,22 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
           )}
           {tab === 1 && (
             <div className="settings-panel">
-              <FormField label="Theme">
+              <FormField label="Theme" tooltip="Application color theme">
                 <EnumSelect values={THEMES} value={theme} onChange={(v) => setLocalTheme(v)} />
               </FormField>
-              <FormField label="Console">
+              <FormField label="Console" tooltip="Target console; determines the frame rate used for delay calculations">
                 <EnumSelect values={CONSOLES} value={timer.console} onChange={(v) => setTimer({ ...timer, console: v })} />
               </FormField>
-              <FormField label="Custom Framerate (FPS)" visible={timer.console === Console.CUSTOM}>
+              <FormField label="Custom Framerate (FPS)" visible={timer.console === Console.CUSTOM} tooltip="Framerate of your custom console in frames per second">
                 <FloatInput value={timer.customFramerate} onChange={(v) => setTimer({ ...timer, customFramerate: v })} min={0.001} max={INT_MAX} />
               </FormField>
-              <FormField label="Refresh Interval">
+              <FormField label="Refresh Interval" tooltip="How often the timer updates in milliseconds; lower values are smoother but use more CPU">
                 <IntInput value={timer.refreshInterval} onChange={(v) => setTimer({ ...timer, refreshInterval: v ?? 8 })} min={1} max={INT_MAX} />
               </FormField>
-              <FormField label="Precision Calibration">
+              <FormField label="Minimum Length (s)" tooltip="Minimum total timer duration in seconds before a minute is added; reduce this if your target falls naturally within a short window (e.g. ~8s on DS/Lite)">
+                <IntInput value={timer.minimumLength} onChange={(v) => setTimer({ ...timer, minimumLength: v ?? 14 })} min={0} max={INT_MAX} />
+              </FormField>
+              <FormField label="Precision Calibration" tooltip="Store calibration in milliseconds rather than delays for sub-frame precision">
                 <label className="checkbox-label">
                   <input
                     type="checkbox"

--- a/src/components/common/FormField.tsx
+++ b/src/components/common/FormField.tsx
@@ -5,14 +5,15 @@ interface FormFieldProps {
   children: React.ReactNode;
   visible?: boolean;
   htmlFor?: string;
+  tooltip?: string;
 }
 
-export function FormField({ label, children, visible = true, htmlFor }: FormFieldProps) {
+export function FormField({ label, children, visible = true, htmlFor, tooltip }: FormFieldProps) {
   if (!visible) return null;
   return (
     <div className="form-field">
       <label className="form-field-label" htmlFor={htmlFor}>{label}</label>
-      <div className="form-field-input">{children}</div>
+      <div className="form-field-input" title={tooltip}>{children}</div>
     </div>
   );
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -84,6 +84,7 @@ export interface TimerSettings {
   customFramerate: number;
   precisionCalibration: boolean;
   refreshInterval: number;
+  minimumLength: number; // in seconds
 }
 
 export interface SettingsState {
@@ -120,6 +121,7 @@ export const DEFAULT_TIMER: TimerSettings = {
   customFramerate: 60.0,
   precisionCalibration: false,
   refreshInterval: 8,
+  minimumLength: 14,
 };
 
 export const DEFAULT_GEN5: Gen5Settings = {
@@ -178,6 +180,19 @@ export const useSettingsStore = create<SettingsState>()(
           theme: Theme.SYSTEM,
         }),
     }),
-    { name: 'eontimer-settings' },
+    { name: 'eontimer-settings',
+      merge: (persisted: unknown, current: SettingsState): SettingsState => {
+        const p = persisted as Partial<SettingsState>;
+        return {
+          ...current,
+          ...p,
+          action: { ...current.action, ...p.action },
+          timer: { ...current.timer, ...p.timer },
+          gen5: { ...current.gen5, ...p.gen5 },
+          gen4: { ...current.gen4, ...p.gen4 },
+          gen3: { ...current.gen3, ...p.gen3 },
+        };
+      },
+    },
   ),
 );

--- a/src/timers/calibrator.ts
+++ b/src/timers/calibrator.ts
@@ -9,6 +9,7 @@ export interface CalibratorSettings {
   console: Console;
   customFramerate: number;
   precisionCalibration: boolean;
+  minimumLength: number; // in milliseconds
 }
 
 function getFramerate(settings: CalibratorSettings): number {

--- a/src/timers/delayTimer.ts
+++ b/src/timers/delayTimer.ts
@@ -13,7 +13,8 @@ export function createDelayPhases(
   calibration: number,
 ): number[] {
   const phase1 = toMinimumLength(
-    createSecondPhases(targetSecond, calibration)[0] - toMilliseconds(settings, targetDelay),
+    createSecondPhases(targetSecond, calibration, settings.minimumLength)[0] - toMilliseconds(settings, targetDelay),
+    settings.minimumLength,
   );
   const phase2 = toMilliseconds(settings, targetDelay) - calibration;
   return [phase1, phase2];

--- a/src/timers/gen5Timer.ts
+++ b/src/timers/gen5Timer.ts
@@ -30,7 +30,7 @@ export function createGen5Phases(settings: CalibratorSettings, model: Gen5Model)
 
   switch (model.mode) {
     case Gen5Mode.STANDARD:
-      return createSecondPhases(model.targetSecond, calibration);
+      return createSecondPhases(model.targetSecond, calibration, settings.minimumLength);
     case Gen5Mode.C_GEAR:
       return createDelayPhases(settings, model.targetDelay, model.targetSecond, calibration);
     case Gen5Mode.ENTRALINK:

--- a/src/timers/secondTimer.ts
+++ b/src/timers/secondTimer.ts
@@ -1,7 +1,7 @@
-import { toMinimumLength } from '../utils/constants';
+import { toMinimumLength, MINIMUM_LENGTH } from '../utils/constants';
 
-export function createSecondPhases(targetSecond: number, calibration: number): number[] {
-  return [toMinimumLength(targetSecond * 1000 + calibration + 200)];
+export function createSecondPhases(targetSecond: number, calibration: number, minimumLength: number = MINIMUM_LENGTH): number[] {
+  return [toMinimumLength(targetSecond * 1000 + calibration + 200, minimumLength)];
 }
 
 export function calibrateSecond(targetSecond: number, secondHit: number): number {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -3,8 +3,8 @@ export const INT_MAX = 2 ** 31 - 1;
 export const INT_MIN = -(2 ** 31 - 1);
 export const MINIMUM_LENGTH = 14000;
 
-export function toMinimumLength(value: number): number {
-  while (value < MINIMUM_LENGTH) {
+export function toMinimumLength(value: number, minimumLength: number = MINIMUM_LENGTH): number {
+  while (value < minimumLength) {
     value += 60000;
   }
   return value;


### PR DESCRIPTION
## Summary

Adds a user-configurable **Minimum Length** setting (in seconds) to the Timer settings tab. This controls the minimum total timer duration before a minute is automatically added — previously hard-coded at 14 seconds.

## Motivation

On DS/Lite hardware it's possible to target seed windows that naturally fall below the 14s threshold, causing EonTimer to incorrectly add a full minute. Users can now lower this value (e.g. to 6–8s) to match their hardware's capabilities.

## Changes

- **New setting**: minimumLength (seconds, default 14) in TimerSettings, persisted to localStorage
- **Timer logic**: 	oMinimumLength, createSecondPhases, and createDelayPhases now accept a minimumLength parameter threaded through CalibratorSettings
- **Settings UI**: New "Minimum Length (s)" field in the Timer tab with a descriptive tooltip
- **Tooltips**: Added 	ooltip prop to FormField (rendered as native 	itle); all Action and Timer settings fields now have tooltips
- **Persist fix**: Custom merge function added to the zustand persist middleware so new nested settings fields always fall back to their defaults on existing installs (fixes "Undefined" display for new fields)
- **Phase recalc fix**: handleSettingsClose now defers phase recalculation with setTimeout so panels re-render with updated settings before createPhases is called (this was silently broken for all timer setting changes)