### PR TITLE
Fix CodeQL: scan javascript-typescript only, drop Python

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,28 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 0 * * 1'
+
+permissions:
+  security-events: write
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+
+      - uses: github/codeql-action/autobuild@v3
+
+      - uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Problem

GitHub's automatic CodeQL configuration detected Python files in the repository and was failing with errors at:
https://github.com/DasAmpharos/EonTimer/security/code-scanning/tools/CodeQL/status/configurations/automatic/8f93893f68c6c24abbe42fc241f6dd520e5bb5affb8d52673a59d9d9c413acf6

## Fix

Add an explicit \.github/workflows/codeql.yml\ that scans only \javascript-typescript\. A custom workflow takes precedence over the automatic configuration, so GitHub will no longer attempt to scan Python.