### PR TITLE
Refactor Mins Before display and fix calibrator rounding

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,8 @@ import { usePhaseRunner } from './hooks/usePhaseRunner';
 import { useTheme } from './hooks/useTheme';
 import { useUrlParams } from './hooks/useUrlParams';
 import { TimerDisplay } from './components/TimerDisplay';
-import { Gen5Panel, type TimerPanelHandle } from './components/Gen5Panel';
+import { Gen5Panel } from './components/Gen5Panel';
+import type { TimerPanelHandle } from './components/timerPanel';
 import { Gen4Panel } from './components/Gen4Panel';
 import { Gen3Panel } from './components/Gen3Panel';
 import { CustomPanel } from './components/CustomPanel';
@@ -42,9 +43,10 @@ export default function App() {
 
   // Update phases when tab or settings change
   const updatePhases = useCallback(() => {
-    const ref = refs[useSettingsStore.getState().tabIndex];
-    const phases = ref?.current?.createPhases();
-    if (phases) setPhases(phases);
+    const tab = useSettingsStore.getState().tabIndex;
+    const ref = refs[tab];
+    const displayData = ref?.current?.createDisplayData();
+    if (displayData) setPhases(displayData.phases, displayData.minutesBeforeTarget);
   }, [setPhases]);
 
   // Initial phases
@@ -59,8 +61,8 @@ export default function App() {
       setTabIndex(index);
       setTimeout(() => {
         const ref = refs[index];
-        const phases = ref?.current?.createPhases();
-        if (phases) setPhases(phases);
+        const displayData = ref?.current?.createDisplayData();
+        if (displayData) setPhases(displayData.phases, displayData.minutesBeforeTarget);
       }, 0);
     },
     [running, setTabIndex, setPhases],

--- a/src/components/CustomPanel.tsx
+++ b/src/components/CustomPanel.tsx
@@ -8,7 +8,7 @@ import { FloatInput } from './common/FloatInput';
 import { EnumSelect } from './common/EnumSelect';
 import { CalibratorSettings } from '../timers/calibrator';
 import { createCustomPhases, calibrateCustomPhase, type CustomPhase } from '../timers/customTimer';
-import type { TimerPanelHandle } from './Gen5Panel';
+import type { TimerPanelHandle } from './timerPanel';
 
 const CUSTOM_UNITS = Object.values(CustomUnit) as CustomUnit[];
 
@@ -50,9 +50,12 @@ export const CustomPanel = forwardRef<TimerPanelHandle, CustomPanelProps>(
       [setCustomPhases],
     );
 
-    const createPhasesCalc = useCallback(() => {
+    const createDisplayData = useCallback(() => {
       const models: CustomPhase[] = phases.map(({ unit, target, calibration }) => ({ unit, target, calibration }));
-      return createCustomPhases(calSettings, models);
+      return {
+        phases: createCustomPhases(calSettings, models),
+        minutesBeforeTarget: null,
+      };
     }, [calSettings, phases]);
 
     const canCalibrate = useCallback(() => {
@@ -76,7 +79,7 @@ export const CustomPanel = forwardRef<TimerPanelHandle, CustomPanelProps>(
       persist(initial);
     }, [persist]);
 
-    useImperativeHandle(ref, () => ({ createPhases: createPhasesCalc, calibrate, canCalibrate, reset }), [createPhasesCalc, calibrate, canCalibrate, reset]);
+    useImperativeHandle(ref, () => ({ createDisplayData, calibrate, canCalibrate, reset }), [createDisplayData, calibrate, canCalibrate, reset]);
 
     const updatePhase = useCallback(
       (index: number, patch: Partial<PhaseState>) => {

--- a/src/components/Gen3Panel.tsx
+++ b/src/components/Gen3Panel.tsx
@@ -8,7 +8,7 @@ import { FloatInput } from './common/FloatInput';
 import { EnumSelect } from './common/EnumSelect';
 import { CalibratorSettings } from '../timers/calibrator';
 import { createGen3Phases, calibrateGen3, createFramePhase } from '../timers/gen3Timer';
-import type { TimerPanelHandle } from './Gen5Panel';
+import type { TimerPanelHandle } from './timerPanel';
 
 const GEN3_MODES = Object.values(Gen3Mode) as Gen3Mode[];
 
@@ -43,8 +43,11 @@ export const Gen3Panel = forwardRef<TimerPanelHandle, Gen3PanelProps>(
       minimumLength: timer.minimumLength * 1000,
     }), [timer.console, timer.customFramerate, timer.precisionCalibration, timer.minimumLength]);
 
-    const createPhases = useCallback(() => {
-      return createGen3Phases(calSettings, gen3);
+    const createDisplayData = useCallback(() => {
+      return {
+        phases: createGen3Phases(calSettings, gen3),
+        minutesBeforeTarget: null,
+      };
     }, [calSettings, gen3]);
 
     const canCalibrate = useCallback(() => frameHit !== null, [frameHit]);
@@ -62,7 +65,7 @@ export const Gen3Panel = forwardRef<TimerPanelHandle, Gen3PanelProps>(
       setTargetFrameLocked(false);
     }, [updateGen3]);
 
-    useImperativeHandle(ref, () => ({ createPhases, calibrate, canCalibrate, reset }), [createPhases, calibrate, canCalibrate, reset]);
+    useImperativeHandle(ref, () => ({ createDisplayData, calibrate, canCalibrate, reset }), [createDisplayData, calibrate, canCalibrate, reset]);
 
     const update = useCallback(
       (patch: Partial<typeof gen3>) => {

--- a/src/components/Gen4Panel.tsx
+++ b/src/components/Gen4Panel.tsx
@@ -4,8 +4,8 @@ import { INT_MAX, INT_MIN } from '../utils/constants';
 import { FormField } from './common/FormField';
 import { IntInput } from './common/IntInput';
 import { CalibratorSettings } from '../timers/calibrator';
-import { createGen4Phases, calibrateGen4 } from '../timers/gen4Timer';
-import type { TimerPanelHandle } from './Gen5Panel';
+import { createGen4Phases, calibrateGen4, getGen4MinutesBeforeTarget } from '../timers/gen4Timer';
+import type { TimerPanelHandle } from './timerPanel';
 
 interface Gen4PanelProps {
   onPhasesChange: () => void;
@@ -27,8 +27,12 @@ export const Gen4Panel = forwardRef<TimerPanelHandle, Gen4PanelProps>(
       minimumLength: timer.minimumLength * 1000,
     }), [timer.console, timer.customFramerate, timer.precisionCalibration, timer.minimumLength]);
 
-    const createPhases = useCallback(() => {
-      return createGen4Phases(calSettings, gen4);
+    const createDisplayData = useCallback(() => {
+      const phases = createGen4Phases(calSettings, gen4);
+      return {
+        phases,
+        minutesBeforeTarget: getGen4MinutesBeforeTarget(calSettings, gen4),
+      };
     }, [calSettings, gen4]);
 
     const canCalibrate = useCallback(() => delayHit !== null, [delayHit]);
@@ -45,7 +49,7 @@ export const Gen4Panel = forwardRef<TimerPanelHandle, Gen4PanelProps>(
       setDelayHit(null);
     }, [updateGen4]);
 
-    useImperativeHandle(ref, () => ({ createPhases, calibrate, canCalibrate, reset }), [createPhases, calibrate, canCalibrate, reset]);
+    useImperativeHandle(ref, () => ({ createDisplayData, calibrate, canCalibrate, reset }), [createDisplayData, calibrate, canCalibrate, reset]);
 
     const update = useCallback(
       (patch: Partial<typeof gen4>) => {

--- a/src/components/Gen5Panel.tsx
+++ b/src/components/Gen5Panel.tsx
@@ -6,16 +6,11 @@ import { FormField } from './common/FormField';
 import { IntInput } from './common/IntInput';
 import { EnumSelect } from './common/EnumSelect';
 import { CalibratorSettings } from '../timers/calibrator';
-import { createGen5Phases, calibrateGen5 } from '../timers/gen5Timer';
+import { createGen5Phases, calibrateGen5, getGen5MinutesBeforeTarget } from '../timers/gen5Timer';
+import type { TimerPanelHandle } from './timerPanel';
+export type { TimerPanelData, TimerPanelHandle } from './timerPanel';
 
 const GEN5_MODES = Object.values(Gen5Mode) as Gen5Mode[];
-
-export interface TimerPanelHandle {
-  createPhases: () => number[];
-  calibrate: () => void;
-  canCalibrate: () => boolean;
-  reset: () => void;
-}
 
 interface Gen5PanelProps {
   onPhasesChange: () => void;
@@ -39,8 +34,12 @@ export const Gen5Panel = forwardRef<TimerPanelHandle, Gen5PanelProps>(
       minimumLength: timer.minimumLength * 1000,
     }), [timer.console, timer.customFramerate, timer.precisionCalibration, timer.minimumLength]);
 
-    const createPhases = useCallback(() => {
-      return createGen5Phases(calSettings, gen5);
+    const createDisplayData = useCallback(() => {
+      const phases = createGen5Phases(calSettings, gen5);
+      return {
+        phases,
+        minutesBeforeTarget: getGen5MinutesBeforeTarget(calSettings, gen5),
+      };
     }, [calSettings, gen5]);
 
     const canCalibrate = useCallback(() => {
@@ -72,7 +71,7 @@ export const Gen5Panel = forwardRef<TimerPanelHandle, Gen5PanelProps>(
       setAdvancesHit(null);
     }, [updateGen5]);
 
-    useImperativeHandle(ref, () => ({ createPhases, calibrate, canCalibrate, reset }), [createPhases, calibrate, canCalibrate, reset]);
+    useImperativeHandle(ref, () => ({ createDisplayData, calibrate, canCalibrate, reset }), [createDisplayData, calibrate, canCalibrate, reset]);
 
     const update = useCallback(
       (patch: Partial<typeof gen5>) => {

--- a/src/components/TimerDisplay.tsx
+++ b/src/components/TimerDisplay.tsx
@@ -33,6 +33,7 @@ export function TimerDisplay({ registerFlash, onToggle, onSettings, settingsDisa
   const running = useAppStore((s) => s.running);
   const actionInterval = useSettingsStore((s) => s.action.interval);
   const actionCount = useSettingsStore((s) => s.action.count);
+  const minutesBeforeTarget = useAppStore((s) => s.minutesBeforeTarget);
 
   const panelRef = useRef<HTMLDivElement>(null);
   const flashTimeoutRef = useRef<number>(0);
@@ -87,7 +88,7 @@ export function TimerDisplay({ registerFlash, onToggle, onSettings, settingsDisa
       <div className={`timer-progress-bar zone-${displayZone}`}>
         <div className="timer-progress-fill" style={{ transform: `scaleX(${progressValue / 100})` }} />
       </div>
-      <div className="timer-meta">
+      <div className="timer-meta" style={minutesBeforeTarget !== null ? { gridTemplateColumns: '1fr 1fr 1fr 1fr' } : undefined}>
         <span className="timer-info-item">
           <span className="timer-info-label">Phase:</span>
           <span className="mono">{currentPhaseIndex + 1} of {phases.length || 1}</span>
@@ -100,6 +101,12 @@ export function TimerDisplay({ registerFlash, onToggle, onSettings, settingsDisa
           <span className="timer-info-label">Total:</span>
           <span className="mono">{formatTotal(phases)}</span>
         </span>
+        {minutesBeforeTarget !== null && (
+          <span className="timer-info-item" title="Set your clock this many minutes before your target time">
+            <span className="timer-info-label">Mins Before:</span>
+            <span className="mono">{minutesBeforeTarget}</span>
+          </span>
+        )}
       </div>
       <div className="timer-display-footer">
         <button className="timer-settings-btn" onClick={onSettings} disabled={settingsDisabled} title="Open Settings (Ctrl+,)">

--- a/src/components/timerPanel.ts
+++ b/src/components/timerPanel.ts
@@ -1,0 +1,11 @@
+export interface TimerPanelData {
+  phases: number[];
+  minutesBeforeTarget: number | null;
+}
+
+export interface TimerPanelHandle {
+  createDisplayData: () => TimerPanelData;
+  calibrate: () => void;
+  canCalibrate: () => boolean;
+  reset: () => void;
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -10,11 +10,12 @@ import type { CustomPhase } from '../timers/customTimer';
 // ─── App runtime state (not persisted) ───
 export interface AppState {
   phases: number[];
+  minutesBeforeTarget: number | null;
   currentPhaseIndex: number;
   currentPhaseElapsed: number;
   running: boolean;
 
-  setPhases: (phases: number[]) => void;
+  setPhases: (phases: number[], minutesBeforeTarget?: number | null) => void;
   setPhase: (index: number, value: number) => void;
   setCurrentPhaseIndex: (index: number) => void;
   setCurrentPhaseElapsed: (elapsed: number) => void;
@@ -24,11 +25,12 @@ export interface AppState {
 
 export const useAppStore = create<AppState>((set, get) => ({
   phases: [],
+  minutesBeforeTarget: null,
   currentPhaseIndex: 0,
   currentPhaseElapsed: 0,
   running: false,
 
-  setPhases: (phases) => set({ phases, currentPhaseIndex: 0, currentPhaseElapsed: 0 }),
+  setPhases: (phases, minutesBeforeTarget = null) => set({ phases, minutesBeforeTarget, currentPhaseIndex: 0, currentPhaseElapsed: 0 }),
   setPhase: (index, value) => {
     const phases = [...get().phases];
     phases[index] = value;

--- a/src/timers/calibrator.ts
+++ b/src/timers/calibrator.ts
@@ -12,6 +12,29 @@ export interface CalibratorSettings {
   minimumLength: number; // in milliseconds
 }
 
+// Match the desktop timer's C# Math.Round(decimal) midpoint-to-even behavior.
+function roundHalfToEven(value: number): number {
+  if (!Number.isFinite(value)) {
+    return Math.round(value);
+  }
+
+  const lower = Math.floor(value);
+  const upper = Math.ceil(value);
+  if (lower === upper) {
+    return lower;
+  }
+
+  const lowerDistance = value - lower;
+  const upperDistance = upper - value;
+  const epsilon = Number.EPSILON * Math.max(1, Math.abs(value));
+
+  if (Math.abs(lowerDistance - upperDistance) <= epsilon) {
+    return Math.abs(lower) % 2 === 0 ? lower : upper;
+  }
+
+  return lowerDistance < upperDistance ? lower : upper;
+}
+
 function getFramerate(settings: CalibratorSettings): number {
   switch (settings.console) {
     case Console.GBA:
@@ -34,15 +57,15 @@ function getFramerate(settings: CalibratorSettings): number {
 }
 
 export function toDelays(settings: CalibratorSettings, milliseconds: number): number {
-  return Math.floor(milliseconds / getFramerate(settings));
+  return roundHalfToEven(milliseconds / getFramerate(settings));
 }
 
 export function toMilliseconds(settings: CalibratorSettings, delays: number): number {
-  return getFramerate(settings) * delays;
+  return roundHalfToEven(getFramerate(settings) * delays);
 }
 
 export function calibrateToDelays(settings: CalibratorSettings, milliseconds: number): number {
-  return settings.precisionCalibration ? Math.round(milliseconds) : toDelays(settings, milliseconds);
+  return settings.precisionCalibration ? roundHalfToEven(milliseconds) : toDelays(settings, milliseconds);
 }
 
 export function calibrateToMilliseconds(settings: CalibratorSettings, delays: number): number {

--- a/src/timers/gen4Timer.ts
+++ b/src/timers/gen4Timer.ts
@@ -1,3 +1,4 @@
+import { getMinutesBeforeTarget } from '../utils/constants';
 import {
   CalibratorSettings,
   createCalibration,
@@ -19,6 +20,10 @@ function getCalibration(settings: CalibratorSettings, model: Gen4Model): number 
 
 export function createGen4Phases(settings: CalibratorSettings, model: Gen4Model): number[] {
   return createDelayPhases(settings, model.targetDelay, model.targetSecond, getCalibration(settings, model));
+}
+
+export function getGen4MinutesBeforeTarget(settings: CalibratorSettings, model: Gen4Model): number {
+  return getMinutesBeforeTarget(createDelayPhases(settings, model.targetDelay, model.targetSecond, 0));
 }
 
 export function calibrateGen4(

--- a/src/timers/gen5Timer.ts
+++ b/src/timers/gen5Timer.ts
@@ -1,4 +1,5 @@
 import { Gen5Mode } from '../utils/types';
+import { getMinutesBeforeTarget } from '../utils/constants';
 import {
   CalibratorSettings,
   calibrateToDelays,
@@ -42,6 +43,21 @@ export function createGen5Phases(settings: CalibratorSettings, model: Gen5Model)
         settings, model.targetDelay, model.targetSecond, model.targetAdvances,
         calibration, entralinkCalibration, model.frameCalibration,
       );
+  }
+}
+
+export function getGen5MinutesBeforeTarget(settings: CalibratorSettings, model: Gen5Model): number {
+  switch (model.mode) {
+    case Gen5Mode.STANDARD:
+      return getMinutesBeforeTarget(createSecondPhases(model.targetSecond, 0, settings.minimumLength));
+    case Gen5Mode.C_GEAR:
+      return getMinutesBeforeTarget(createDelayPhases(settings, model.targetDelay, model.targetSecond, 0));
+    case Gen5Mode.ENTRALINK:
+    case Gen5Mode.ENTRALINK_PLUS:
+      return getMinutesBeforeTarget(createEntralinkPhases(settings, model.targetDelay, model.targetSecond, 0, 0));
+    default:
+      model.mode satisfies never;
+      return 0;
   }
 }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -10,6 +10,15 @@ export function toMinimumLength(value: number, minimumLength: number = MINIMUM_L
   return value;
 }
 
+export function getMinutesBeforeTarget(phases: number[]): number {
+  let total = 0;
+  for (const phase of phases) {
+    if (phase === INFINITY) continue;
+    total += phase;
+  }
+  return Math.floor(total / 60000);
+}
+
 // Console framerates
 export const GBA_FPS = 59.7275;
 export const NDS_SLOT1_FPS = 59.8261;


### PR DESCRIPTION
## Summary

### Mins Before display refactor
- **Fix:** Gen 4/5 now always show the Mins Before field, including when the value is `0` (previously hidden due to a falsy check)
- **Refactor:** `TimerPanelHandle.createPhases()` → `createDisplayData()` returning `TimerPanelData { phases, minutesBeforeTarget: number | null }`
  - `null` = hide the field (Gen 3, Custom); a number including `0` = show it (Gen 4, Gen 5)
- **Calibration-free minutes:** `getGen4MinutesBeforeTarget` and `getGen5MinutesBeforeTarget` compute the value with `calibration=0`, so users see the raw target-based guidance rather than calibration-adjusted timing
- **Shared types:** Extracted `TimerPanelHandle` / `TimerPanelData` from `Gen5Panel.tsx` into `src/components/timerPanel.ts`
- **Tooltip:** Added `title` attribute to the Mins Before field: _"Set your clock this many minutes before your target time"_

### Calibrator rounding fix
Aligned `calibrator.ts` with C# `Math.Round` which defaults to **MidpointRounding.ToEven** (banker's rounding):
- `toDelays`: `Math.floor` → `roundHalfToEven` — the floor was systematically under-counting delays on ~50% of values
- `toMilliseconds`: was returning an unrounded float; now rounds to nearest even integer
- `calibrateToDelays` precision mode: `Math.round` (half-away-from-zero) → `roundHalfToEven` to match C# at midpoints

> **Note:** The `toDelays` change affects approximately half of all converted values by ±1 delay, which may shift calibration values for users upgrading from older builds.