### PR TITLE
fix: fire last visual cue when sleep overshoots scheduledTime

### DIFF
--- a/src/workers/timerWorker.ts
+++ b/src/workers/timerWorker.ts
@@ -60,6 +60,11 @@ async function executePhase(
         // tight loop — acceptable in a Worker
         t = now();
       }
+    }
+
+    // Fire all actions that became due — handles both the spin-wait path and
+    // sleep overshoot (setTimeout resolves late, waking past the action time).
+    while (t >= nextAction) {
       self.postMessage({ type: 'action' });
       nextAction = actions.length > 0 ? actions.pop()! : Infinity;
     }


### PR DESCRIPTION
## Problem

Action firing in `executePhase` was only inside the spin-wait (`else`) branch. When `remainingUntilAction` was just barely above `SPINWAIT_MS` (e.g. 2.1ms), the code took the sleep path and calculated `sleepMs ≈ 0` — but `setTimeout(_, 0)` has a minimum ~1–4ms resolution. It would wake up past `scheduledTime`, hit the `break`, and exit **without ever firing the last action**.

This made the last visual cue non-deterministically drop whenever the final action's timing landed in that narrow window.

## Fix

Moved `postMessage({ type: 'action' })` out of the `else` branch into a shared `while (t >= nextAction)` loop that runs after **both** the sleep and spin-wait paths. This drains all due actions regardless of whether a sleep overshot, ensuring the last visual cue always fires.

```ts
// Before: action only fired in the spin-wait branch
} else {
  while (running && t < nextAction) { t = now(); }
  self.postMessage({ type: 'action' });       // ← skipped on sleep overshoot
  nextAction = actions.length > 0 ? actions.pop()! : Infinity;
}

// After: action fired after either branch
} else {
  while (running && t < nextAction) { t = now(); }
}
// Drains all due actions — handles spin-wait and sleep overshoot
while (t >= nextAction) {
  self.postMessage({ type: 'action' });
  nextAction = actions.length > 0 ? actions.pop()! : Infinity;
}
```