### PR TITLE
fix: trigger audio from worker action messages instead of pre-scheduling

### DIFF
--- a/src/audio/sounds.ts
+++ b/src/audio/sounds.ts
@@ -1,12 +1,7 @@
 // Web Audio API sound synthesis — no external files needed.
-// Supports both immediate playback (play*) and pre-scheduled playback
-// (schedule*At) for sample-accurate timing on the hardware audio clock.
 
 let audioCtx: AudioContext | null = null;
 let audioUnlocked = false;
-
-// Track scheduled audio nodes so they can be cancelled on stop/phase change
-const scheduledSources: Set<AudioScheduledSourceNode> = new Set();
 
 function getContext(): AudioContext {
   if (!audioCtx) {
@@ -38,7 +33,7 @@ export function resumeAudio(): void {
   }
 }
 
-// ─── Immediate playback (fire-and-forget) ───
+// ─── Playback (fire-and-forget) ───
 
 function playTone(
   frequency: number,
@@ -113,134 +108,4 @@ export function getSoundPlayer(sound: string): SoundPlayer {
     default:
       return playBeep;
   }
-}
-
-// ─── Pre-scheduled playback (sample-accurate on the audio hardware clock) ───
-
-function trackNode(node: AudioScheduledSourceNode): void {
-  scheduledSources.add(node);
-  node.onended = () => scheduledSources.delete(node);
-}
-
-function scheduleToneAt(
-  audioTime: number,
-  frequency: number,
-  duration: number,
-  type: OscillatorType = 'sine',
-  gain = 0.3,
-): void {
-  const ctx = getContext();
-  const osc = ctx.createOscillator();
-  const vol = ctx.createGain();
-  osc.type = type;
-  osc.frequency.setValueAtTime(frequency, audioTime);
-  vol.gain.setValueAtTime(gain, audioTime);
-  vol.gain.exponentialRampToValueAtTime(0.001, audioTime + duration);
-  osc.connect(vol);
-  vol.connect(ctx.destination);
-  osc.start(audioTime);
-  osc.stop(audioTime + duration);
-  trackNode(osc);
-}
-
-function scheduleBeepAt(audioTime: number): void {
-  scheduleToneAt(audioTime, 800, 0.15, 'sine', 0.4);
-}
-
-function scheduleDingAt(audioTime: number): void {
-  scheduleToneAt(audioTime, 1200, 0.3, 'sine', 0.3);
-}
-
-function schedulePopAt(audioTime: number): void {
-  const ctx = getContext();
-  const osc = ctx.createOscillator();
-  const vol = ctx.createGain();
-  osc.type = 'sine';
-  osc.frequency.setValueAtTime(400, audioTime);
-  osc.frequency.exponentialRampToValueAtTime(100, audioTime + 0.06);
-  vol.gain.setValueAtTime(0.4, audioTime);
-  vol.gain.exponentialRampToValueAtTime(0.001, audioTime + 0.06);
-  osc.connect(vol);
-  vol.connect(ctx.destination);
-  osc.start(audioTime);
-  osc.stop(audioTime + 0.08);
-  trackNode(osc);
-}
-
-function scheduleTickAt(audioTime: number): void {
-  const ctx = getContext();
-  const bufferSize = Math.ceil(ctx.sampleRate * 0.02);
-  const buffer = ctx.createBuffer(1, bufferSize, ctx.sampleRate);
-  const data = buffer.getChannelData(0);
-  for (let i = 0; i < bufferSize; i++) {
-    data[i] = (Math.random() * 2 - 1) * Math.exp(-i / (bufferSize * 0.1));
-  }
-  const source = ctx.createBufferSource();
-  const vol = ctx.createGain();
-  source.buffer = buffer;
-  vol.gain.setValueAtTime(0.3, audioTime);
-  source.connect(vol);
-  vol.connect(ctx.destination);
-  source.start(audioTime);
-  trackNode(source);
-}
-
-function scheduleSoundAt(sound: string, audioTime: number): void {
-  switch (sound) {
-    case 'Ding':
-      scheduleDingAt(audioTime);
-      break;
-    case 'Pop':
-      schedulePopAt(audioTime);
-      break;
-    case 'Tick':
-      scheduleTickAt(audioTime);
-      break;
-    case 'Beep':
-    default:
-      scheduleBeepAt(audioTime);
-      break;
-  }
-}
-
-/**
- * Pre-schedule all audio actions for a phase on the Web Audio timeline.
- * Uses the same action-time calculation as the worker's buildActions():
- * actions are spaced `interval` ms apart, counting back from phase end.
- * Scheduling on the hardware audio clock provides sample-accurate timing
- * (~0.02ms at 48kHz) independent of JavaScript execution jitter.
- */
-export function schedulePhaseActions(
-  phaseDurationMs: number,
-  actionIntervalMs: number,
-  actionCount: number,
-  sound: string,
-): void {
-  if (!isFinite(phaseDurationMs) || phaseDurationMs <= 0) return;
-
-  const ctx = getContext();
-  const now = ctx.currentTime;
-
-  for (let i = 0; i < actionCount; i++) {
-    const offsetFromEndMs = actionIntervalMs * i;
-    if (offsetFromEndMs < phaseDurationMs) {
-      const triggerMs = phaseDurationMs - offsetFromEndMs;
-      scheduleSoundAt(sound, now + triggerMs / 1000);
-    }
-  }
-}
-
-/**
- * Cancel all pre-scheduled audio nodes (e.g. on timer stop or phase change).
- */
-export function cancelAllScheduled(): void {
-  for (const node of scheduledSources) {
-    try {
-      node.stop();
-      node.disconnect();
-    } catch {
-      // Node may already be stopped/disconnected
-    }
-  }
-  scheduledSources.clear();
 }

--- a/src/hooks/usePhaseRunner.ts
+++ b/src/hooks/usePhaseRunner.ts
@@ -1,6 +1,6 @@
 import { useRef, useCallback, useEffect } from 'react';
 import { useAppStore, useSettingsStore } from '../store';
-import { resumeAudio, schedulePhaseActions, cancelAllScheduled } from '../audio/sounds';
+import { resumeAudio, getSoundPlayer } from '../audio/sounds';
 import { ActionMode } from '../utils/types';
 
 export function usePhaseRunner() {
@@ -18,7 +18,6 @@ export function usePhaseRunner() {
   useEffect(() => {
     return () => {
       workerRef.current?.terminate();
-      cancelAllScheduled();
     };
   }, []);
 
@@ -53,7 +52,6 @@ export function usePhaseRunner() {
 
     console.info('[PhaseRunner] Starting phase runner');
     resumeAudio();
-    cancelAllScheduled();
 
     const worker = new Worker(new URL('../workers/timerWorker.ts', import.meta.url), {
       type: 'module',
@@ -61,11 +59,9 @@ export function usePhaseRunner() {
     workerRef.current = worker;
 
     const actionMode = action.mode;
-    const actionInterval = action.interval;
-    const actionCount = action.count;
-    const actionSound = action.sound;
     const useAudio = actionMode === ActionMode.AV || actionMode === ActionMode.AUDIO;
     const useVisual = actionMode === ActionMode.AV || actionMode === ActionMode.VISUAL;
+    const soundPlayer = useAudio ? getSoundPlayer(action.sound) : null;
 
     worker.onmessage = (e: MessageEvent) => {
       const { type } = e.data;
@@ -77,37 +73,17 @@ export function usePhaseRunner() {
           const phaseIndex = e.data.phaseIndex;
           useAppStore.getState().setCurrentPhaseIndex(phaseIndex);
           useAppStore.getState().setCurrentPhaseElapsed(0);
-          // Pre-schedule audio for the new phase on the Web Audio timeline
-          if (useAudio) {
-            const currentPhases = useAppStore.getState().phases;
-            schedulePhaseActions(
-              currentPhases[phaseIndex],
-              actionInterval,
-              actionCount,
-              actionSound,
-            );
-          }
           break;
         }
-        case 'phaseResolved':
-          // Infinite phase resolved to a finite value: schedule audio cues
-          // using the remaining time so they land at the correct absolute moment.
-          if (useAudio) {
-            schedulePhaseActions(e.data.remaining, actionInterval, actionCount, actionSound);
-          }
-          break;
         case 'action':
-          // Audio is pre-scheduled on the Web Audio timeline for
-          // sample-accurate timing; action messages only drive visual flash
+          if (useAudio) {
+            soundPlayer!();
+          }
           if (useVisual) {
             flashRef.current?.();
           }
           break;
         case 'finished':
-          // Delay cleanup so the last pre-scheduled audio cue finishes
-          // playing — it fires at approximately the same wall-clock moment
-          // this message arrives, creating a race with cancelAllScheduled.
-          setTimeout(() => cancelAllScheduled(), 500);
           useAppStore.getState().setRunning(false);
           break;
       }
@@ -122,15 +98,9 @@ export function usePhaseRunner() {
       actionCount: action.count,
       refreshInterval: timer.refreshInterval,
     });
-
-    // Pre-schedule audio for the first phase
-    if (useAudio) {
-      schedulePhaseActions(phases[0], actionInterval, actionCount, actionSound);
-    }
   }, [setRunning]);
 
   const stop = useCallback(() => {
-    cancelAllScheduled();
     if (workerRef.current) {
       console.info('[PhaseRunner] Stopping phase runner');
       workerRef.current.postMessage({ type: 'stop' });


### PR DESCRIPTION
## Problem

Audio beeps could desync from the timer because they were pre-scheduled on the Web Audio API hardware clock (`AudioContext.currentTime`) at the start of each phase, while visual flashes were triggered by the worker's `action` messages using `performance.now()`. These two clocks can drift over time.

## Solution

Both audio and visual cues are now triggered from the same source — the worker's `action` messages. This ensures beeps and flashes always fire in lockstep with the timer.

### Changes
- **`usePhaseRunner.ts`** — Removed `schedulePhaseActions`/`cancelAllScheduled` calls. The `action` handler now plays sounds immediately via `getSoundPlayer()`.
- **`sounds.ts`** — Removed ~130 lines of pre-scheduling infrastructure (`schedule*At`, `schedulePhaseActions`, `cancelAllScheduled`, `scheduledSources` tracking).