### PR TITLE
fix: bypass iOS silent switch for timer audio

### DIFF
--- a/src/audio/sounds.ts
+++ b/src/audio/sounds.ts
@@ -18,6 +18,12 @@ function getContext(): AudioContext {
  * Must be called from a user-gesture event handler (click/tap/keydown).
  */
 export function resumeAudio(): void {
+  // Request "playback" audio session so audio is heard even when the iOS
+  // silent switch is on (Safari 17+). No-ops on unsupported browsers.
+  if ('audioSession' in navigator) {
+    (navigator.audioSession as { type: string }).type = 'playback';
+  }
+
   const ctx = getContext();
   if (ctx.state === 'suspended') {
     ctx.resume();


### PR DESCRIPTION
## Problem

When the iOS silent switch is on, no audio plays from the timer. iOS classifies web audio as "ambient" by default, which respects the silent switch.

## Solution

Sets `navigator.audioSession.type = 'playback'` in `resumeAudio()`, which tells iOS to treat the audio like media playback (similar to Spotify). This bypasses the silent switch so timer beeps are always audible.

- Works on Safari 17+ (iOS 17+)
- No-ops on browsers that don't support the Audio Session API