### PR TITLE
fix: warm up AudioContext from user gesture to avoid first beep delay

### DIFF
--- a/src/audio/sounds.ts
+++ b/src/audio/sounds.ts
@@ -28,7 +28,9 @@ export function resumeAudio(): void {
   if (ctx.state === 'suspended') {
     ctx.resume();
   }
-  // iOS requires playing a buffer from a user gesture to fully unlock audio
+  // iOS requires playing a buffer from a user gesture to fully unlock audio.
+  // Also serves as a warmup to prime the audio pipeline so the first real
+  // beep doesn't suffer extra latency from oscillator creation.
   if (!audioUnlocked) {
     audioUnlocked = true;
     const buf = ctx.createBuffer(1, 1, ctx.sampleRate);

--- a/src/hooks/usePhaseRunner.ts
+++ b/src/hooks/usePhaseRunner.ts
@@ -51,7 +51,6 @@ export function usePhaseRunner() {
     const absoluteStart = performance.timeOrigin + performance.now();
 
     console.info('[PhaseRunner] Starting phase runner');
-    resumeAudio();
 
     const worker = new Worker(new URL('../workers/timerWorker.ts', import.meta.url), {
       type: 'module',
@@ -111,7 +110,9 @@ export function usePhaseRunner() {
   }, [setRunning]);
 
   const toggle = useCallback(() => {
-    // Resume audio in the user-gesture call stack (required by iOS Safari / Chrome autoplay policy)
+    // Resume audio in the user-gesture call stack (required by iOS Safari /
+    // Chrome autoplay policy). Also warms up the AudioContext so it is fully
+    // active by the time the first action fires.
     resumeAudio();
     if (useAppStore.getState().running) {
       stop();


### PR DESCRIPTION
## Problem

The first audio cue could be delayed or early depending on `AudioContext.resume()` latency. Awaiting the resume skewed the timing anchor; not awaiting it left the context still waking up.

## Solution

`resumeAudio()` is called synchronously from `toggle()` in the user-gesture call stack, which initiates `ctx.resume()` and plays a silent buffer to prime the audio pipeline. `start()` remains fully synchronous so `absoluteStart` is captured immediately without async skew. By the time the first worker action fires (seconds into the countdown), the AudioContext is fully active and the beep plays on time.