### PR TITLE
refactor: eagerly create timer worker on mount

### DIFF
--- a/src/hooks/usePhaseRunner.ts
+++ b/src/hooks/usePhaseRunner.ts
@@ -3,6 +3,12 @@ import { useAppStore, useSettingsStore } from '../store';
 import { resumeAudio, getSoundPlayer } from '../audio/sounds';
 import { ActionMode } from '../utils/types';
 
+function createWorker(): Worker {
+  return new Worker(new URL('../workers/timerWorker.ts', import.meta.url), {
+    type: 'module',
+  });
+}
+
 export function usePhaseRunner() {
   const workerRef = useRef<Worker | null>(null);
   const flashRef = useRef<(() => void) | null>(null);
@@ -15,9 +21,12 @@ export function usePhaseRunner() {
     flashRef.current = fn;
   }, []);
 
+  // Create the worker eagerly on mount so it's ready for the first start
   useEffect(() => {
+    workerRef.current = createWorker();
     return () => {
       workerRef.current?.terminate();
+      workerRef.current = null;
     };
   }, []);
 
@@ -45,17 +54,15 @@ export function usePhaseRunner() {
     const { action, timer } = useSettingsStore.getState();
     if (phases.length === 0) return;
 
+    const worker = workerRef.current;
+    if (!worker) return;
+
     // Capture the click time as an absolute timestamp before any async work.
     // Sent to the worker so it can anchor scheduledTime to this moment rather
     // than to the worker's own (later) time origin.
     const absoluteStart = performance.timeOrigin + performance.now();
 
     console.info('[PhaseRunner] Starting phase runner');
-
-    const worker = new Worker(new URL('../workers/timerWorker.ts', import.meta.url), {
-      type: 'module',
-    });
-    workerRef.current = worker;
 
     const actionMode = action.mode;
     const useAudio = actionMode === ActionMode.AV || actionMode === ActionMode.AUDIO;
@@ -104,7 +111,8 @@ export function usePhaseRunner() {
       console.info('[PhaseRunner] Stopping phase runner');
       workerRef.current.postMessage({ type: 'stop' });
       workerRef.current.terminate();
-      workerRef.current = null;
+      // Immediately create a fresh worker so it's ready for the next start
+      workerRef.current = createWorker();
     }
     setRunning(false);
   }, [setRunning]);


### PR DESCRIPTION
## Summary

Updates the timer worker lifecycle to create the Web Worker eagerly on mount rather than lazily on each start. This eliminates worker creation delay from the start path.

### Changes
- Extract `createWorker()` helper to avoid duplication
- Create the worker on hook mount so it's pre-loaded and ready
- `start()` reuses the existing worker instead of creating a new one
- `stop()` terminates the worker and immediately spawns a fresh one for the next run
- Cleanup on unmount still terminates the worker