### PR TITLE
Add inputMode to numeric inputs for mobile keypad support

### DIFF
--- a/src/components/common/FloatInput.tsx
+++ b/src/components/common/FloatInput.tsx
@@ -46,6 +46,7 @@ export function FloatInput({
     <input
       id={id}
       type="text"
+      inputMode="decimal"
       className="float-input"
       value={text}
       onChange={handleChange}

--- a/src/components/common/IntInput.tsx
+++ b/src/components/common/IntInput.tsx
@@ -61,6 +61,7 @@ export function IntInput({
     <input
       id={id}
       type="text"
+      inputMode={radix === 10 ? 'numeric' : 'text'}
       className="int-input"
       value={text}
       onChange={handleChange}


### PR DESCRIPTION
## Summary

Adds the HTML `inputMode` attribute to `IntInput` and `FloatInput` components so mobile browsers show the appropriate numeric keypad instead of a full text keyboard.

## Changes

- **`IntInput`**: `inputMode="numeric"` for base-10 inputs; falls back to `"text"` for hex (`radix=16`) since users need A–F characters.
- **`FloatInput`**: `inputMode="decimal"` to show the number pad with a decimal point key.

Since all ~27 numeric input fields across the app use these two shared components, this fix applies everywhere automatically.