### PR TITLE
Add version and commit hash display to footer

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -549,6 +549,14 @@ input[type='checkbox'] {
   text-align: center;
 }
 
+.app-version {
+  font-size: 10px;
+  color: var(--color-text-secondary);
+  opacity: 0.5;
+  text-align: center;
+  flex-shrink: 0;
+}
+
 /* ─── Custom panel ─── */
 .custom-scroll {
   padding: 10px;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -225,6 +225,11 @@ export default function App() {
         <div className="app-status-bar">
           <span>{statusMessage}</span>
         </div>
+
+        {/* Version footer */}
+        <div className="app-version">
+          {__APP_VERSION__} ({__COMMIT_HASH__})
+        </div>
       </div>
 
       {/* Settings dialog */}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,7 +3,7 @@ import { createRoot } from 'react-dom/client';
 import App from './App';
 import './index.css';
 
-console.info(`[EonTimer] version=2026.03.01`);
+console.info(`[EonTimer] version=${__APP_VERSION__} commit=${__COMMIT_HASH__}`);
 console.info(`[EonTimer] platform=${navigator.platform}, userAgent=${navigator.userAgent}`);
 
 createRoot(document.getElementById('root')!).render(

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,4 @@
 /// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string;
+declare const __COMMIT_HASH__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,16 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { VitePWA } from 'vite-plugin-pwa';
+import { execSync } from 'child_process';
+const commitHash = execSync('git rev-parse --short HEAD').toString().trim();
+const commitDate = execSync('git log -1 --format=%cs').toString().trim().replaceAll('-', '.');
 
 export default defineConfig({
   base: '/EonTimer/',
+  define: {
+    __APP_VERSION__: JSON.stringify(commitDate),
+    __COMMIT_HASH__: JSON.stringify(commitHash),
+  },
   plugins: [
     react(),
     VitePWA({


### PR DESCRIPTION
## Summary

Displays the build version and commit hash in a small footer below the status bar, making it easy to identify which commit is deployed and detect stale caches.

## How it works

- **Version derived from git at build time** — `git log -1 --format=%cs` provides the last commit's date as CalVer (`YYYY.MM.DD`), `git rev-parse --short HEAD` provides the short SHA
- Injected as `__APP_VERSION__` and `__COMMIT_HASH__` via Vite `define` — no manual version maintenance needed
- Console log updated to use the same injected values

## Layout

- Status bar remains fully centered with its existing messages
- Version sits in its own thin row below: small, dimmed, centered (e.g. `2026.03.22 (5fe7bcf)`)
- No horizontal crowding on mobile

## Files changed

| File | Change |
|------|--------|
| `vite.config.ts` | Inject version + commit hash at build time |
| `src/vite-env.d.ts` | TypeScript declarations for globals |
| `src/main.tsx` | Console log uses injected values |
| `src/App.tsx` | Version footer below status bar |
| `src/App.css` | Styling for version footer |