### PR TITLE
fix: prevent audio from being throttled in background tabs

### DIFF
--- a/src/audio/sounds.ts
+++ b/src/audio/sounds.ts
@@ -49,6 +49,10 @@ function startKeepAlive(): void {
   keepAliveGain = audioCtx.createGain();
   keepAliveGain.gain.value = 1e-5; // non-zero — Chrome optimises away gain=0
   keepAliveOsc.connect(keepAliveGain);
+  // Route to streamDest so the MediaStream stays active (signals browser media
+  // is playing, preventing background-tab throttling). Also route to
+  // audioCtx.destination to keep the hardware pipeline warm between beeps so
+  // Chrome doesn't idle the output device and swallow the first real sound.
   keepAliveGain.connect(streamDest);
   keepAliveGain.connect(audioCtx.destination);
   keepAliveOsc.start();
@@ -89,6 +93,18 @@ export async function resumeAudio(): Promise<void> {
   }
 }
 
+/**
+ * Fire-and-forget wrapper for resumeAudio().
+ *
+ * Does NOT guarantee the AudioContext is fully resumed before the next sound
+ * plays — callers that need that guarantee should `await resumeAudio()`.
+ * Intended for synchronous call sites (e.g. test-action button) where
+ * best-effort resume is acceptable.
+ */
+export function resumeAudioSync(): void {
+  void resumeAudio();
+}
+
 let resumePromise: Promise<void> | null = null;
 
 /** Coordinate keepalive lifecycle with timer start/stop. */
@@ -99,6 +115,12 @@ export function setTimerRunning(active: boolean): void {
     keepAliveEl.play().catch(() => {});
   } else {
     stopKeepAlive();
+    try {
+      keepAliveEl.pause();
+    } catch {
+      // ignore pause errors
+    }
+    keepAliveEl.currentTime = 0;
   }
 }
 
@@ -108,9 +130,17 @@ function ensureRunning(): Promise<void> {
     return Promise.resolve();
   }
   if (!resumePromise) {
-    resumePromise = audioCtx.resume().then(() => {
-      resumePromise = null;
-    });
+    resumePromise = audioCtx
+      .resume()
+      .then(() => {
+        resumePromise = null;
+      })
+      .catch((err) => {
+        // Clear on failure so the next call can retry instead of reusing a
+        // permanently-rejected promise.
+        resumePromise = null;
+        throw err;
+      });
   }
   return resumePromise;
 }

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -6,7 +6,7 @@ import { FormField } from './common/FormField';
 import { IntInput } from './common/IntInput';
 import { FloatInput } from './common/FloatInput';
 import { EnumSelect } from './common/EnumSelect';
-import { getSoundPlayer, resumeAudio } from '../audio/sounds';
+import { getSoundPlayer, resumeAudioSync } from '../audio/sounds';
 
 const ACTION_MODES = Object.values(ActionMode) as ActionMode[];
 const ACTION_SOUNDS = Object.values(ActionSound) as ActionSound[];
@@ -62,7 +62,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
   }, [resetAll, onClose]);
 
   const handleTestAction = useCallback(() => {
-    resumeAudio();
+    resumeAudioSync();
     getSoundPlayer(action.sound)(performance.timeOrigin + performance.now());
   }, [action.sound]);
 

--- a/src/hooks/usePhaseRunner.ts
+++ b/src/hooks/usePhaseRunner.ts
@@ -95,13 +95,13 @@ export function usePhaseRunner() {
           break;
         }
         case 'finished':
-          setTimerRunning(false);
+          if (useAudio) setTimerRunning(false);
           useAppStore.getState().setRunning(false);
           break;
       }
     };
 
-    setTimerRunning(true);
+    if (useAudio) setTimerRunning(true);
     setRunning(true);
     worker.postMessage({
       type: 'start',


### PR DESCRIPTION
**Changes:**
- Added a MediaStreamDestination + hidden <audio> element keepalive system that signals to the browser that media is active, preventing background tab throttling.
- Added a sub-audible keepalive oscillator (gain 1e-5) that runs during timer phases to keep the audio hardware from idling.
- Split audio routing: sounds go directly to audioCtx.destination for full quality; keepalive routes through MediaStreamDestination separately.
- Added ensureRunning() fallback in playBuffer() to resume the AudioContext if it's suspended when a sound fires.
- Made resumeAudio() async so the AudioContext is guaranteed active before the timer starts.
- Added setTimerRunning() to coordinate keepalive lifecycle with timer start/stop/finish.
- Made toggle() in usePhaseRunner async to await resumeAudio() before starting.

resolves:
#226 (and #220 fully)
