### PR TITLE
fix: eliminate full-volume transient on keepalive oscillator start

### DIFF
--- a/src/audio/sounds.ts
+++ b/src/audio/sounds.ts
@@ -47,7 +47,12 @@ function startKeepAlive(): void {
   if (keepAliveOsc) return;
   keepAliveOsc = audioCtx.createOscillator();
   keepAliveGain = audioCtx.createGain();
-  keepAliveGain.gain.value = 1e-5; // non-zero — Chrome optimises away gain=0
+  // Schedule gain at t=0 (always in the past) so it is guaranteed to be
+  // applied from the very first rendering quantum. Using gain.value (which is
+  // setValueAtTime at currentTime) risks a one-quantum window where the
+  // GainNode default of 1.0 is in effect, producing a loud transient.
+  // 1e-5 is non-zero so Chrome doesn't optimise the node away.
+  keepAliveGain.gain.setValueAtTime(1e-5, 0);
   keepAliveOsc.connect(keepAliveGain);
   // Route to streamDest so the MediaStream stays active (signals browser media
   // is playing, preventing background-tab throttling). Also route to


### PR DESCRIPTION
## Problem

Fixes #229

When starting the timer, users occasionally heard a loud clipping sound. This happened ~50% of the time due to a race condition introduced in #227.

## Root Cause

In `startKeepAlive()`, the keepalive `GainNode` is created with a default gain of **1.0**. The line:

```ts
keepAliveGain.gain.value = 1e-5;
```

is equivalent to `setValueAtTime(1e-5, audioCtx.currentTime)`. The Web Audio API processes audio in 128-sample rendering quanta (~2.9ms at 44.1kHz). If `currentTime` is at or near a quantum boundary when this runs, the gain change may not take effect until the **next** quantum.

Meanwhile, `keepAliveOsc.start()` starts the oscillator immediately (at time 0). For that one-quantum window, the oscillator outputs at the default gain of **1.0** (full volume, 440 Hz), producing an audible transient that clips audio systems near their limits.

The ~50% probability matches the chance that JS execution falls near a quantum boundary when `currentTime` is read.

## Fix

Schedule the gain at `t=0` instead:

```ts
keepAliveGain.gain.setValueAtTime(1e-5, 0);
```

`t=0` is always in the past relative to any rendering quantum. The Web Audio API spec guarantees that a `setValueAtTime` event at `t=0` is applied from the very first quantum the node renders, eliminating the race entirely.