### PR TITLE
fix: update timer phases after calibration (Update button)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,7 +75,7 @@ export default function App() {
     const ref = currentRef?.current;
     if (ref && ref.canCalibrate()) {
       ref.calibrate();
-      updatePhases();
+      setTimeout(updatePhases, 0);
       setStatusMessage('Calibration applied.');
       setTimeout(() => setStatusMessage('Ready'), 4000);
     }


### PR DESCRIPTION
## Problem

Fixes #230

In **Gen 4** (and also Gen 3 and Gen 5), clicking **Update** after entering a hit value updated the calibration settings in the store, but the timer display did not refresh. The workaround of manually editing the calibration field afterward worked because those edits go through a different code path.

## Root Cause

In `handleUpdate` (App.tsx), the call sequence was:

```ts
ref.calibrate();  // updates Zustand store (Gen3/Gen4/Gen5 panels)
updatePhases();   // reads createDisplayData() — STALE closure!
```

The `calibrate()` in Gen3/Gen4/Gen5 panels updates Zustand state, but `createDisplayData` is a `useCallback` that captured the old store values in its closure. React hasn't had a chance to re-render the panel with the new values yet, so `createDisplayData` computes phases from the **pre-calibration** settings. The timer display showed no change.

**Why manual field edits worked:** field changes go through an `update()` helper that calls `setTimeout(onPhasesChange, 0)`, giving React one event-loop tick to re-render before `createDisplayData` is invoked. The `handleUpdate` path was the only call site that called `updatePhases()` synchronously.

## Fix

One-line change — wrap `updatePhases()` in `setTimeout(..., 0)` in `handleUpdate`, exactly matching every other call site in App.tsx (`handleReset`, `handleSettingsClose`, the initial `useEffect`, and all panel field-level `update()` helpers):

```ts
// before
ref.calibrate();
updatePhases();

// after
ref.calibrate();
setTimeout(updatePhases, 0);
```

This affects Gen 3, Gen 4, and Gen 5 timers (all three have `calibrate()` implementations that update Zustand without calling `onPhasesChange` themselves). The Custom timer is unaffected — its `calibrate()` already calls `setTimeout(onPhasesChange, 0)` internally.