### PR TITLE
fix(ci): restore dotfile upload and add checkout to deploy job

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -40,3 +40,4 @@ jobs:
           name: pr-preview
           path: dist/
           retention-days: 1
+          include-hidden-files: true

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -21,6 +21,10 @@ jobs:
     if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
       - uses: actions/download-artifact@v8
         with:
           name: pr-preview


### PR DESCRIPTION
## Root cause

The Dependabot bump of `actions/upload-artifact` from v4 to v7 (#253) introduced two bugs:

### Bug 1: `dist/.pr-number` silently dropped from artifact

`upload-artifact@v7` **excludes hidden files (dotfiles) by default**. The `.pr-number` file was never included in the artifact, so the deploy job's `cat dist/.pr-number` always failed.

**Fix:** Add `include-hidden-files: true` to the upload step in `pr-build.yml`.

### Bug 2: `fatal: not in a git directory`

The `deploy` job in `pr-preview.yml` had no `actions/checkout` step. `JamesIves/github-pages-deploy-action` runs `git config user.name` (non-global) which requires a git repository context in the working directory.

**Fix:** Add `actions/checkout@v6` as the first step in the deploy job.

Fixes the failure at https://github.com/DasAmpharos/EonTimer/actions/runs/23724850191/job/69106369541